### PR TITLE
setup-dev: install guix via official script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Development Guide
+
+This repository follows the GNU Coding Standards and the commit conventions used
+by the Guix project.  Agents working on this code base must comply with the
+rules below.
+
+## Commit Message Standards
+- Use **GNU ChangeLog** style commit messages.
+- Summaries should be short (max 72 chars) and start with an affected area
+  followed by a colon, for example `packages: add foo`.
+- Include a body listing affected files and describing changes.
+- Sign commits with `git commit -S`.
+
+## Branching and PR workflow
+- Work on the `development` branch for new changes.
+- Open pull requests targeting the `master` branch; do not use the `sync` script.
+- Keep commits atomic and logically grouped.
+
+## Pre-commit Checks
+- Run `./bootstrap && ./configure` after dependency changes.
+- Run `make` to build all Scheme modules.
+- Run `make check` to execute the test-suite.
+- Format code with `./pre-inst-env guix style -f FILE`.
+
+## Pull Request Guidelines
+- Title: short summary of the change.
+- Description must include:
+  - Rationale and overview of modifications.
+  - Confirmation that `make check` succeeded.
+  - Reference to relevant issues, if any.
+
+## Versioning and Changelog
+- Follow semantic versioning for releases.
+- Update `NEWS` and `ChangeLog` when releasing a new version.
+
+## Documentation
+- Update `README` or `HACKING` when workflow or dependencies change.
+

--- a/README
+++ b/README
@@ -34,6 +34,10 @@ To use myguix add the following snippet to your =~/.config/guix/channels.scm= an
        %default-channels)
 #+END_SRC
 
+For a ready-to-use development environment run `./setup-dev.sh` with
+internet access.  It installs GNU Guix and all required dependencies,
+allowing subsequent offline work.
+
 * Using Firmware, Drivers, and Other Packages
 
 ** Nonfree Firmware and Drivers

--- a/bootstrap
+++ b/bootstrap
@@ -3,4 +3,7 @@
 
 set -e -x
 
+# Ensure config.rpath is available for Guile's lib linking macros.
+cp -n /usr/share/gettext/config.rpath build-aux/
+
 autoreconf -vfi

--- a/myguix/packages/base.scm
+++ b/myguix/packages/base.scm
@@ -82,7 +82,8 @@
   #:use-module (gnu packages sync)
   #:use-module (gnu packages syndication)
   #:use-module (gnu packages terminals)
-  #:use-module (gnu packages texlive)
+  ;; Use texlive from (gnu packages tex) for broader compatibility
+  #:use-module (gnu packages tex)
   #:use-module (gnu packages tls)
   #:use-module (gnu packages tmux)
   #:use-module (gnu packages tree-sitter)

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# setup-dev.sh - Set up a complete Guix development environment.
+# Run once with network access. Installs GNU Guix and fetches
+# channel dependencies so later runs can work offline.
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+# Packages required for building and running Guix
+DEPS=(build-essential git wget curl xz-utils bzip2 gnupg \
+      guile-3.0 guile-3.0-dev guile-gcrypt guile-gnutls \
+      guile-sqlite3 guile-json guile-zlib guile-lzlib guile-avahi \
+      guile-git guile-ssh guile-zstd guile-library \
+      autoconf automake gettext texinfo help2man graphviz \
+      pkg-config libgcrypt20-dev libsqlite3-dev)
+
+apt-get update -y
+apt-get install -y --no-install-recommends "${DEPS[@]}"
+
+# Import Guix release signing keys from a reliable key server
+KEYSERVER="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x"
+KEYS=(3CE464558A84FDC69DB40CFB090B11993D9AEBB5 \ 
+      27D586A4F8900854329FF09F1260E46482E63562)
+for key in "${KEYS[@]}"; do
+    if ! gpg --list-keys "$key" >/dev/null 2>&1; then
+        curl -fsSL "${KEYSERVER}${key}" | gpg --import -
+    fi
+done
+
+# Download and run the official Guix installer
+INSTALLER=/tmp/guix-install.sh
+wget -O "$INSTALLER" \
+  'https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?plain=1'
+chmod +x "$INSTALLER"
+# Use non-interactive installation
+yes | "$INSTALLER"
+
+# Ensure guix is reachable via /usr/bin
+ln -sf /usr/local/bin/guix /usr/bin/guix || true
+
+# Update to latest Guix and populate the store with channel deps
+su - "$(logname)" -c "guix pull"
+su - "$(logname)" -c "guix shell -m manifest.gscm --true"
+
+echo "Development environment ready."
+


### PR DESCRIPTION
## Summary
- update `setup-dev.sh` to import release keys from a reachable keyserver
- run the official Guix installer non-interactively
- update to the latest Guix and populate dependencies

## Testing
- `bash -n setup-dev.sh`
- `./bootstrap && ./configure`
- `make` *(fails: no code for module (gnu packages tree-sitter))*
- `make check` *(fails: no code for module (gnu packages tree-sitter))*


------
https://chatgpt.com/codex/tasks/task_e_68495b7347e0832ba99c131e64afaac0