### PR TITLE
Improve bazel build system

### DIFF
--- a/myguix/build/bazel-build-system.scm
+++ b/myguix/build/bazel-build-system.scm
@@ -24,7 +24,7 @@
   #:use-module (ice-9 match)
   #:use-module (ice-9 string-fun)
   #:use-module (srfi srfi-1)
-  #:export (%standard-phases bazel-build))
+  #:export (%standard-phases bazel-build unpack-vendored-inputs))
 
 ;; Commentary:
 ;;
@@ -71,6 +71,8 @@
   (define %bazel-user-root
     (string-append %build-directory "/tmp"))
   (setenv "USER" "homeless-shelter")
+  ;; Ensure HOME is set for tools that rely on it.
+  (setenv "HOME" %build-directory)
   (apply invoke
          "bazel"
          "--batch"

--- a/tests/bazel-build-system.scm
+++ b/tests/bazel-build-system.scm
@@ -1,0 +1,20 @@
+(use-modules (srfi srfi-64)
+             (myguix build bazel-build-system)
+             (guix build utils)
+             (guix utils))
+
+(test-begin "bazel build system")
+
+(test-assert "unpack sets HOME"
+  (call-with-temporary-directory
+   (lambda (tmp)
+    (let* ((tar (string-append tmp "/deps.tar"))
+           (external-dir (string-append tmp "/external")))
+      (mkdir-p external-dir)
+      (call-with-output-file (string-append external-dir "/foo") (lambda (_) (display "")))
+      (invoke "tar" "cf" tar "-C" tmp "external")
+      (setenv "NIX_BUILD_TOP" tmp)
+      (unpack-vendored-inputs #:vendored-inputs tar)
+      (string=? (getenv "HOME") tmp)))))
+
+(test-end)


### PR DESCRIPTION
## Summary
- export `unpack-vendored-inputs`
- ensure `HOME` is set during the Bazel build phase
- add regression test for `unpack-vendored-inputs`

## Testing
- `guile -L . tests/bazel-build-system.scm`

------
https://chatgpt.com/codex/tasks/task_e_684b32ba7c58832bb4738c6359511733